### PR TITLE
View and download files

### DIFF
--- a/chatez/src/pages/Chats/Components/ChatFeedProfilePanel/ChatFeedProfilePanel.css
+++ b/chatez/src/pages/Chats/Components/ChatFeedProfilePanel/ChatFeedProfilePanel.css
@@ -13,6 +13,63 @@
   overflow-y: auto;
 }
 
+.ImageModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.ImageModalContent {
+  display: inline-block;
+  background: white;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.ImageModalContent img {
+  display: block;
+  max-width: 90vw;
+  max-height: 90vh;
+  width: auto;
+  height: auto;
+  border-radius: 10px;
+}
+
+.ImageModalContent img:active {
+  transform: scale(0.98);
+}
+
+.ImageModalContent {
+  background: white;
+  padding: 10px;
+  border-radius: 8px;
+  cursor: auto;
+}
+
+.ImageModal:hover {
+  cursor: pointer;
+}
+
+#DownloadFile-button {
+  color: white;
+  margin-left: 105px;
+}
+
+#DownloadImage-button {
+  color: #3a483f;
+}
+
+#DownloadIcon {
+  font-size: 45px;
+}
+
 .ChatFeedProfilePanel-Collapsed {
   transform: translateX(280px);
 }

--- a/chatez/src/pages/Chats/Components/ChatFeedProfilePanel/ChatFeedProfilePanel.tsx
+++ b/chatez/src/pages/Chats/Components/ChatFeedProfilePanel/ChatFeedProfilePanel.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../../../../contexts/authContext';
 import { removeFriend } from '../../../../backend/endpoints';
 import MenuIcon from '@mui/icons-material/Menu';
 import { Alert, IconButton } from '@mui/material';
+import { FileDownloadSharp } from '@mui/icons-material';
 
 interface ChatFeedProfilePanelProps {
   className?: string;
@@ -19,6 +20,8 @@ const ChatFeedProfilePanel: React.FC<ChatFeedProfilePanelProps> = ({
   const { currentUserAccessToken } = useAuth();
 
   const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const [expandedImage, setExpandedImage] = useState<string | null>(null);
 
   const deleteConversation = () => {
     console.log('Conversation has been deleted');
@@ -45,15 +48,53 @@ const ChatFeedProfilePanel: React.FC<ChatFeedProfilePanelProps> = ({
   };
 
   useEffect(() => {
+    // Map through all messages between the users and check for files being shared,
+    // which are not other files i.e ending in .pdf, .docx  etc ....
+    // set sharedImages to store all images exchanged between the 2 users, insted of the test images
     setSharedImages([
       'https://i.pinimg.com/736x/3d/cd/4a/3dcd4af5bc9e06d36305984730ab7888.jpg',
       'https://storage.googleapis.com/chatez-438923.firebasestorage.app/MessageFiles%2F56rolsj%40gmail.com-1731362731422-phoenix_cropped.png',
     ]);
-    setSharedFiles(['DocumentExample1.docx', 'DocumentExample2.docx']);
+
+    // Map through all messages between the users and check for files being shared,
+    // which are not images i.e ending in .png, .jpeg .gif etc ....
+    // set sharedFiles to store all files exchanged between the 2 users, insted of testFile.pdf
+    setSharedFiles(['testFile.pdf']);
   }, []);
 
   const toggleCollapse = () => {
     setIsCollapsed((prevState) => !prevState);
+  };
+
+  const expandImage = (imageSrc: string) => {
+    setExpandedImage(imageSrc);
+  };
+
+  const closeExpandedImage = () => {
+    setExpandedImage(null);
+  };
+
+  // in parameters, pass through the fileUrl and fileName, fileName might be same as fileUrl
+  const downloadFile = () => {
+    const fileName = 'Test';
+    const fileUrl = `https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf`; // Replace with actual file path
+    const link = document.createElement('a');
+    link.href = fileUrl;
+    link.target = '_blank'; // Open in a new tab
+    link.download = fileName; // Set the file name for the download
+    link.click();
+  };
+
+  // we don't need the downloadImage function, we will reuse downloadfile for images
+  // this function is just here for test purposes, remove it when adding backend
+  const downloadImage = () => {
+    const fileName = 'Test';
+    const fileUrl = `https://storage.googleapis.com/chatez-438923.firebasestorage.app/MessageFiles%2F56rolsj%40gmail.com-1731362731422-phoenix_cropped.png`; // Replace with actual file path
+    const link = document.createElement('a');
+    link.href = fileUrl;
+    link.target = '_blank'; // Open in a new tab
+    link.download = fileName; // Set the file name for the download
+    link.click();
   };
 
   return (
@@ -88,6 +129,7 @@ const ChatFeedProfilePanel: React.FC<ChatFeedProfilePanelProps> = ({
             className="SharedImage"
             src={image}
             alt="Shared Media"
+            onClick={() => expandImage(image)}
           />
         ))}
       </div>
@@ -97,6 +139,9 @@ const ChatFeedProfilePanel: React.FC<ChatFeedProfilePanelProps> = ({
       {sharedFiles.map((file, index) => (
         <p key={index} className="Document">
           {file}
+          <IconButton id="DownloadFile-button" onClick={downloadFile}>
+            <FileDownloadSharp />
+          </IconButton>
         </p>
       ))}
 
@@ -109,6 +154,20 @@ const ChatFeedProfilePanel: React.FC<ChatFeedProfilePanelProps> = ({
           Remove Friend
         </button>
       </div>
+
+      {expandedImage && (
+        <div className="ImageModal" onClick={closeExpandedImage}>
+          <div
+            className="ImageModalContent"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <img src={expandedImage} alt="Expanded Media" />
+            <IconButton id="DownloadImage-button" onClick={downloadImage}>
+              <FileDownloadSharp id="DownloadIcon" />
+            </IconButton>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
view and download files

**NOTES** 
- this does not link with back end at all, the files and images are simply test images
Just needs simple logic and use of endpoints to connect with backend

- @X2Abdul - can you complete the logic side, this shouldn't be overly complicated for you as it should collect the images, similarly as how you did it for messages.

- I have included some notes within ChatFeedProfilePanel.tsx which explains what needs to be done, shouldn't take too long.

images expand when clicked on
![image](https://github.com/user-attachments/assets/0e02d410-3039-451b-995e-f281612c8611)

images can be downloaded
![image](https://github.com/user-attachments/assets/8bca74c1-f50c-4e5b-a453-47a967f7f6ac)

files can be downloaded
![image](https://github.com/user-attachments/assets/e5c4e2bb-3587-47c9-9a80-bb8b6eda2065)

![image](https://github.com/user-attachments/assets/e6fae256-33c2-4c2d-8d48-63fd4b1593db)

